### PR TITLE
Child and Spy incompatibility

### DIFF
--- a/Source Code/.gitignore
+++ b/Source Code/.gitignore
@@ -1,2 +1,3 @@
 bin
 obj
+.idea


### PR DESCRIPTION
I have rework my last PR with the new version 2.6.6

If a Child spawn, the Spy can't spawn.

When a bad child and spy spawn at the same time. The 2nd impostor know immediately who his mate is. Because the bad child cannot be spy at the same time.

Conversely if the bad child and the spy cannot spawn at the same time. The spy will immediately know that the child is a good child.

It's for these reason, I think the Child and Spy are incompatible.