### PR TITLE
Feature/tracker retrack

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -354,7 +354,7 @@ namespace TheOtherRoles
                 },
                 () => { return Tracker.tracker != null && Tracker.tracker == PlayerControl.LocalPlayer && !PlayerControl.LocalPlayer.Data.IsDead; },
                 () => { return PlayerControl.LocalPlayer.CanMove && Tracker.currentTarget != null && !Tracker.usedTracker; },
-                () => { },
+                () => { if(Tracker.targetResetAfterMeeting) Tracker.resetTracked(); },
                 Tracker.getButtonSprite(),
                 new Vector3(-1.3f, 0, 0),
                 __instance,

--- a/TheOtherRoles/CustomOptions.cs
+++ b/TheOtherRoles/CustomOptions.cs
@@ -130,6 +130,7 @@ namespace TheOtherRoles {
 
         public static CustomOption trackerSpawnRate;
         public static CustomOption trackerUpdateIntervall;
+        public static CustomOption trackerTargetResetAfterMeeting;
 
         public static CustomOption snitchSpawnRate;
         public static CustomOption snitchLeftTasksForImpostors;
@@ -309,6 +310,7 @@ namespace TheOtherRoles {
 
             trackerSpawnRate = CustomOption.Create(200, cs(Tracker.color, "Tracker"), rates, null, true);
             trackerUpdateIntervall = CustomOption.Create(201, "Tracker Update Intervall", 5f, 2.5f, 30f, 2.5f, trackerSpawnRate);
+            trackerTargetResetAfterMeeting = CustomOption.Create(202, "Tracker Target Reset After Meeting", false, trackerSpawnRate);
 
             snitchSpawnRate = CustomOption.Create(210, cs(Snitch.color, "Snitch"), rates, null, true);
             snitchLeftTasksForImpostors = CustomOption.Create(211, "Task Count Where Impostors See Snitch", 1f, 0f, 5f, 1f, snitchSpawnRate);

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -568,7 +568,7 @@ namespace TheOtherRoles
             targetResetAfterMeeting = CustomOptionHolder.trackerTargetResetAfterMeeting.getBool();
             if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);
             arrow = new Arrow(Color.blue);
-            if (arrow.arrow != null) arrow.arrow.SetActive(true);
+            if (arrow.arrow != null) arrow.arrow.SetActive(false);
         }
     }
 

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -533,6 +533,7 @@ namespace TheOtherRoles
         public static Color color = new Color32(100, 58, 220, byte.MaxValue);
 
         public static float updateIntervall = 5f;
+        public static bool targetResetAfterMeeting = false;
 
         public static PlayerControl currentTarget;
         public static PlayerControl tracked;
@@ -547,6 +548,16 @@ namespace TheOtherRoles
             return buttonSprite;
         }
 
+        public static void resetTracked()
+        {
+            currentTarget = null;
+            tracked = null;
+            usedTracker = false;
+            if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);
+            arrow = new Arrow(Color.blue);
+            if (arrow.arrow != null) arrow.arrow.SetActive(true);
+        }
+
         public static void clearAndReload() {
             tracker = null;
             currentTarget = null;
@@ -554,10 +565,11 @@ namespace TheOtherRoles
             usedTracker = false;
             timeUntilUpdate = 0f;
             updateIntervall = CustomOptionHolder.trackerUpdateIntervall.getFloat();
+            targetResetAfterMeeting = CustomOptionHolder.trackerTargetResetAfterMeeting.getBool();
             if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);
             arrow = new Arrow(Color.blue);
-            if (arrow.arrow != null) arrow.arrow.SetActive(false);
-        }
+            if (arrow.arrow != null) arrow.arrow.SetActive(true);
+            }
     }
 
     public static class Vampire {

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -569,7 +569,7 @@ namespace TheOtherRoles
             if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);
             arrow = new Arrow(Color.blue);
             if (arrow.arrow != null) arrow.arrow.SetActive(true);
-            }
+        }
     }
 
     public static class Vampire {


### PR DESCRIPTION
Give the ability to tracker to track another target after the meeting.

Main problem with tracker is tthat people will randomly track someone T1 and can easly regret their choice. Also the tracker will alway have someone to track every round that dont make his gameplay boring if your tracked die. 