### PR TITLE
seperate guesser role

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -776,7 +776,7 @@ namespace TheOtherRoles
                         }
                     }
                 }
-            );
+            );       
 
             // Set the default (or settings from the previous game) timers/durations when spawning the buttons
             setCustomButtonCooldowns();

--- a/TheOtherRoles/CustomOptions.cs
+++ b/TheOtherRoles/CustomOptions.cs
@@ -50,9 +50,11 @@ namespace TheOtherRoles {
         public static CustomOption loversBothDie;
         public static CustomOption loversCanHaveAnotherRole;
 
-        public static CustomOption guesserSpawnRate;
-        public static CustomOption guesserIsImpGuesserRate;
-        public static CustomOption guesserNumberOfShots;
+        public static CustomOption badGuesserSpawnRate;
+        public static CustomOption badGuesserNumberOfShots;
+
+        public static CustomOption goodGuesserSpawnRate;
+        public static CustomOption goodGuesserNumberOfShots;
 
         public static CustomOption jesterSpawnRate;
         public static CustomOption jesterCanCallEmergency;
@@ -226,6 +228,9 @@ namespace TheOtherRoles {
             bountyHunterShowArrow = CustomOption.Create(324, "Show Arrow Pointing Towards The Bounty", true, bountyHunterSpawnRate);
             bountyHunterArrowUpdateIntervall = CustomOption.Create(325, "Arrow Update Intervall", 15f, 2.5f, 60f, 2.5f, bountyHunterShowArrow);
 
+            badGuesserSpawnRate = CustomOption.Create(405, cs(BadGuesser.color, "Bad Guesser"), rates, null, true);
+            badGuesserNumberOfShots = CustomOption.Create(406, "Guesser Number Of Shots", 2f, 1f, 15f, 1f, badGuesserSpawnRate);
+
 
             miniSpawnRate = CustomOption.Create(180, cs(Mini.color, "Mini"), rates, null, true);
             miniGrowingUpDuration = CustomOption.Create(181, "Mini Growing Up Duration", 400f, 100f, 1500f, 100f, miniSpawnRate);
@@ -234,10 +239,6 @@ namespace TheOtherRoles {
             loversImpLoverRate = CustomOption.Create(51, "Chance That One Lover Is Impostor", rates, loversSpawnRate);
             loversBothDie = CustomOption.Create(52, "Both Lovers Die", true, loversSpawnRate);
             loversCanHaveAnotherRole = CustomOption.Create(53, "Lovers Can Have Another Role", true, loversSpawnRate);
-
-            guesserSpawnRate = CustomOption.Create(310, cs(Guesser.color, "Guesser"), rates, null, true);
-            guesserIsImpGuesserRate = CustomOption.Create(311, "Chance That The Guesser Is An Impostor", rates, guesserSpawnRate);
-            guesserNumberOfShots = CustomOption.Create(312, "Guesser Number Of Shots", 2f, 1f, 15f, 1f, guesserSpawnRate);
 
             jesterSpawnRate = CustomOption.Create(60, cs(Jester.color, "Jester"), rates, null, true);
             jesterCanCallEmergency = CustomOption.Create(61, "Jester can call emergency meeting", true, jesterSpawnRate);
@@ -324,6 +325,9 @@ namespace TheOtherRoles {
             securityGuardTotalScrews = CustomOption.Create(282, "Security Guard Number Of Screws", 7f, 1f, 15f, 1f, securityGuardSpawnRate);
             securityGuardCamPrice = CustomOption.Create(283, "Number Of Screws Per Cam", 2f, 1f, 15f, 1f, securityGuardSpawnRate);
             securityGuardVentPrice = CustomOption.Create(284, "Number Of Screws Per Vent", 1f, 1f, 15f, 1f, securityGuardSpawnRate);
+
+            goodGuesserSpawnRate = CustomOption.Create(410, cs(GoodGuesser.color, "Good Guesser"), rates, null, true);
+            goodGuesserNumberOfShots = CustomOption.Create(411, "Guesser Number Of Shots", 2f, 1f, 15f, 1f, goodGuesserSpawnRate);
 
             // Other options
             maxNumberOfMeetings = CustomOption.Create(3, "Number Of Meetings (excluding Mayor meeting)", 10, 0, 15, 1, null, true);
@@ -643,9 +647,9 @@ namespace TheOtherRoles {
             var hudString = sb.ToString();
 
             int defaultSettingsLines = 19;
-            int roleSettingsLines = defaultSettingsLines + 34;
-            int detailedSettingsP1 = roleSettingsLines + 37;
-            int detailedSettingsP2 = detailedSettingsP1 + 38;
+            int roleSettingsLines = defaultSettingsLines + 38;
+            int detailedSettingsP1 = roleSettingsLines + 39;
+            int detailedSettingsP2 = detailedSettingsP1 + 40;
             int end1 = hudString.TakeWhile(c => (defaultSettingsLines -= (c == '\n' ? 1 : 0)) > 0).Count();
             int end2 = hudString.TakeWhile(c => (roleSettingsLines -= (c == '\n' ? 1 : 0)) > 0).Count();
             int end3 = hudString.TakeWhile(c => (detailedSettingsP1 -= (c == '\n' ? 1 : 0)) > 0).Count();
@@ -662,10 +666,10 @@ namespace TheOtherRoles {
                 gap = 5;
                 index = hudString.TakeWhile(c => (gap -= (c == '\n' ? 1 : 0)) > 0).Count();
                 hudString = hudString.Insert(index, "\n");
-                gap = 18;
+                gap = 19;
                 index = hudString.TakeWhile(c => (gap -= (c == '\n' ? 1 : 0)) > 0).Count();
                 hudString = hudString.Insert(index + 1, "\n");
-                gap = 22;
+                gap = 23;
                 index = hudString.TakeWhile(c => (gap -= (c == '\n' ? 1 : 0)) > 0).Count();
                 hudString = hudString.Insert(index + 1, "\n");
             } else if (counter == 2) {

--- a/TheOtherRoles/Patches/MeetingPatch.cs
+++ b/TheOtherRoles/Patches/MeetingPatch.cs
@@ -1,15 +1,12 @@
 using HarmonyLib;
 using Hazel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnhollowerBaseLib;
-using static TheOtherRoles.TheOtherRoles;
-using static TheOtherRoles.MapOptions;
-using System.Collections;
-using System;
-using System.Text;
 using UnityEngine;
-using System.Reflection;
+using static TheOtherRoles.MapOptions;
+using static TheOtherRoles.TheOtherRoles;
 
 namespace TheOtherRoles.Patches {
     [HarmonyPatch]
@@ -218,15 +215,15 @@ namespace TheOtherRoles.Patches {
             }
         }
 
-        private static GameObject guesserUI;
-        static void guesserOnClick(int buttonTarget, MeetingHud __instance) {
-            if (guesserUI != null || !(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted)) return;
+        private static GameObject badGuesserUI;
+        static void badGuesserOnClick(int buttonTarget, MeetingHud __instance) {
+            if (badGuesserUI != null || !(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted)) return;
             __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(false));
 
             Transform container = UnityEngine.Object.Instantiate(__instance.transform.FindChild("Background"), __instance.transform);
             container.FindChild("BlackBG").gameObject.SetActive(false);
             container.transform.localPosition = new Vector3(0, 0, -5f);
-            guesserUI = container.gameObject;
+            badGuesserUI = container.gameObject;
 
             int i = 0;
             var buttonTemplate = __instance.playerStates[0].transform.FindChild("votePlayerBase");
@@ -251,7 +248,7 @@ namespace TheOtherRoles.Patches {
             Transform selectedButton = null;
 
             foreach (RoleInfo roleInfo in RoleInfo.allRoleInfos) {
-                if (roleInfo.roleId == RoleId.Lover || roleInfo.roleId == RoleId.Guesser || roleInfo == RoleInfo.niceMini) continue; // Not guessable roles
+                if (roleInfo.roleId == RoleId.Lover || roleInfo.roleId == RoleId.BadGuesser || roleInfo == RoleInfo.niceMini) continue; // Not guessable roles
                 Transform buttonParent = (new GameObject()).transform;
                 buttonParent.SetParent(container);
                 Transform button = UnityEngine.Object.Instantiate(buttonTemplate, buttonParent);
@@ -274,17 +271,17 @@ namespace TheOtherRoles.Patches {
                         buttons.ForEach(x => x.GetComponent<SpriteRenderer>().color = x == selectedButton ? Color.red : Color.white);
                     } else {
                         PlayerControl target = Helpers.playerById((byte)__instance.playerStates[buttonTarget].TargetPlayerId);
-                        if (!(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted) || target == null || Guesser.remainingShots <= 0 ) return;
+                        if (!(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted) || target == null || BadGuesser.remainingShots <= 0 ) return;
 
                         var mainRoleInfo = RoleInfo.getRoleInfoForPlayer(target).FirstOrDefault();
                         if (mainRoleInfo == null) return;
 
                         target = (mainRoleInfo == roleInfo) ? target : PlayerControl.LocalPlayer;
 
-                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.GuesserShoot, Hazel.SendOption.Reliable, -1);
+                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.BadGuesserShoot, Hazel.SendOption.Reliable, -1);
                         writer.Write(target.PlayerId);
                         AmongUsClient.Instance.FinishRpcImmediately(writer);
-                        RPCProcedure.guesserShoot(target.PlayerId);
+                        RPCProcedure.badGuesserShoot(target.PlayerId);
 
                         __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(true));
                         UnityEngine.Object.Destroy(container.gameObject);
@@ -297,13 +294,94 @@ namespace TheOtherRoles.Patches {
             container.transform.localScale *= 0.75f;
         }
 
+        private static GameObject goodGuesserUI;
+        static void goodGuesserOnClick(int buttonTarget, MeetingHud __instance) {
+            if(goodGuesserUI != null || !(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted)) return;
+            __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(false));
+
+            Transform container = UnityEngine.Object.Instantiate(__instance.transform.FindChild("Background"), __instance.transform);
+            container.FindChild("BlackBG").gameObject.SetActive(false);
+            container.transform.localPosition = new Vector3(0, 0, -5f);
+            goodGuesserUI = container.gameObject;
+
+            int i = 0;
+            var buttonTemplate = __instance.playerStates[0].transform.FindChild("votePlayerBase");
+            var maskTemplate = __instance.playerStates[0].transform.FindChild("MaskArea");
+            var smallButtonTemplate = __instance.playerStates[0].Buttons.transform.Find("CancelButton");
+            var textTemplate = __instance.playerStates[0].NameText;
+
+            Transform exitButtonParent = (new GameObject()).transform;
+            exitButtonParent.SetParent(container);
+            Transform exitButton = UnityEngine.Object.Instantiate(buttonTemplate.transform, exitButtonParent);
+            Transform exitButtonMask = UnityEngine.Object.Instantiate(maskTemplate, exitButtonParent);
+            exitButton.gameObject.GetComponent<SpriteRenderer>().sprite = smallButtonTemplate.GetComponent<SpriteRenderer>().sprite;
+            exitButtonParent.transform.localPosition = new Vector3(2.725f, 2.1f, -5);
+            exitButtonParent.transform.localScale = new Vector3(0.25f, 0.9f, 1);
+            exitButton.GetComponent<PassiveButton>().OnClick.RemoveAllListeners();
+            exitButton.GetComponent<PassiveButton>().OnClick.AddListener((UnityEngine.Events.UnityAction)(() => {
+                __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(true));
+                UnityEngine.Object.Destroy(container.gameObject);
+            }));
+
+            List<Transform> buttons = new List<Transform>();
+            Transform selectedButton = null;
+
+            foreach(RoleInfo roleInfo in RoleInfo.allRoleInfos) {
+                if(roleInfo.roleId == RoleId.Lover || roleInfo.roleId == RoleId.GoodGuesser || roleInfo == RoleInfo.niceMini) continue; // Not guessable roles
+                Transform buttonParent = (new GameObject()).transform;
+                buttonParent.SetParent(container);
+                Transform button = UnityEngine.Object.Instantiate(buttonTemplate, buttonParent);
+                Transform buttonMask = UnityEngine.Object.Instantiate(maskTemplate, buttonParent);
+                TMPro.TextMeshPro label = UnityEngine.Object.Instantiate(textTemplate, button);
+                buttons.Add(button);
+                int row = i / 4, col = i % 4;
+                buttonParent.localPosition = new Vector3(-2.725f + 1.83f * col, 1.5f - 0.45f * row, -5);
+                buttonParent.localScale = new Vector3(0.55f, 0.55f, 1f);
+                label.text = Helpers.cs(roleInfo.color, roleInfo.name);
+                label.alignment = TMPro.TextAlignmentOptions.Center;
+                label.transform.localPosition = new Vector3(0, 0, label.transform.localPosition.z);
+                label.transform.localScale *= 1.7f;
+                int copiedIndex = i;
+
+                button.GetComponent<PassiveButton>().OnClick.RemoveAllListeners();
+                button.GetComponent<PassiveButton>().OnClick.AddListener((UnityEngine.Events.UnityAction)(() => {
+                    if(selectedButton != button) {
+                        selectedButton = button;
+                        buttons.ForEach(x => x.GetComponent<SpriteRenderer>().color = x == selectedButton ? Color.red : Color.white);
+                    } else {
+                        PlayerControl target = Helpers.playerById((byte)__instance.playerStates[buttonTarget].TargetPlayerId);
+                        if(!(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted) || target == null || GoodGuesser.remainingShots <= 0) return;
+
+                        var mainRoleInfo = RoleInfo.getRoleInfoForPlayer(target).FirstOrDefault();
+                        if(mainRoleInfo == null) return;
+
+                        target = (mainRoleInfo == roleInfo) ? target : PlayerControl.LocalPlayer;
+
+                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.GoodGuesserShoot, Hazel.SendOption.Reliable, -1);
+                        writer.Write(target.PlayerId);
+                        AmongUsClient.Instance.FinishRpcImmediately(writer);
+                        RPCProcedure.goodGuesserShoot(target.PlayerId);
+
+                        __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(true));
+                        UnityEngine.Object.Destroy(container.gameObject);
+                        __instance.playerStates.ToList().ForEach(x => { if(x.transform.FindChild("ShootButton") != null) UnityEngine.Object.Destroy(x.transform.FindChild("ShootButton").gameObject); });
+                    }
+                }));
+
+                i++;
+            }
+            container.transform.localScale *= 0.75f;
+        }
+
+
         [HarmonyPatch(typeof(PlayerVoteArea), nameof(PlayerVoteArea.Select))]
         class PlayerVoteAreaSelectPatch {
             static bool Prefix(MeetingHud __instance) {
-                return !(PlayerControl.LocalPlayer != null && PlayerControl.LocalPlayer == Guesser.guesser && guesserUI != null);
+                return !(PlayerControl.LocalPlayer != null 
+                    && ((PlayerControl.LocalPlayer == BadGuesser.guesser && badGuesserUI != null) || (PlayerControl.LocalPlayer == GoodGuesser.guesser && goodGuesserUI != null))
+                    );
             }
         }
-
 
         static void populateButtonsPostfix(MeetingHud __instance) {
             // Add Swapper Buttons
@@ -334,25 +412,46 @@ namespace TheOtherRoles.Patches {
                 }
             }
 
-            // Add Guesser Buttons
-            if (Guesser.guesser != null && PlayerControl.LocalPlayer == Guesser.guesser && !Guesser.guesser.Data.IsDead && Guesser.remainingShots >= 0) {
+            // Add BadGuesser Buttons
+            if (BadGuesser.guesser != null && PlayerControl.LocalPlayer == BadGuesser.guesser && !BadGuesser.guesser.Data.IsDead && BadGuesser.remainingShots >= 0) {
                 for (int i = 0; i < __instance.playerStates.Length; i++) {
                     PlayerVoteArea playerVoteArea = __instance.playerStates[i];
-                    if (playerVoteArea.AmDead || playerVoteArea.TargetPlayerId == Guesser.guesser.PlayerId) continue;
+                    if (playerVoteArea.AmDead || playerVoteArea.TargetPlayerId == BadGuesser.guesser.PlayerId) continue;
 
                     GameObject template = playerVoteArea.Buttons.transform.Find("CancelButton").gameObject;
                     GameObject targetBox = UnityEngine.Object.Instantiate(template, playerVoteArea.transform);
                     targetBox.name = "ShootButton";
                     targetBox.transform.localPosition = new Vector3(-0.95f, 0.03f, -1f);
                     SpriteRenderer renderer = targetBox.GetComponent<SpriteRenderer>();
-                    renderer.sprite = Guesser.getTargetSprite();
+                    renderer.sprite = BadGuesser.getTargetSprite();
                     PassiveButton button = targetBox.GetComponent<PassiveButton>();
                     button.OnClick.RemoveAllListeners();
                     int copiedIndex = i;
-                    button.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => guesserOnClick(copiedIndex, __instance)));
+                    button.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => badGuesserOnClick(copiedIndex, __instance)));
+                }
+            }
+
+            // Add GoodGuesser Buttons
+            if(GoodGuesser.guesser != null && PlayerControl.LocalPlayer == GoodGuesser.guesser && !GoodGuesser.guesser.Data.IsDead && GoodGuesser.remainingShots >= 0) {
+                for(int i = 0; i < __instance.playerStates.Length; i++) {
+                    PlayerVoteArea playerVoteArea = __instance.playerStates[i];
+                    if(playerVoteArea.AmDead || playerVoteArea.TargetPlayerId == GoodGuesser.guesser.PlayerId) continue;
+
+                    GameObject template = playerVoteArea.Buttons.transform.Find("CancelButton").gameObject;
+                    GameObject targetBox = UnityEngine.Object.Instantiate(template, playerVoteArea.transform);
+                    targetBox.name = "ShootButton";
+                    targetBox.transform.localPosition = new Vector3(-0.95f, 0.03f, -1f);
+                    SpriteRenderer renderer = targetBox.GetComponent<SpriteRenderer>();
+                    renderer.sprite = GoodGuesser.getTargetSprite();
+                    PassiveButton button = targetBox.GetComponent<PassiveButton>();
+                    button.OnClick.RemoveAllListeners();
+                    int copiedIndex = i;
+                    button.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => goodGuesserOnClick(copiedIndex, __instance)));
                 }
             }
         }
+
+
 
         [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.ServerStart))]
         class MeetingServerStartPatch {

--- a/TheOtherRoles/Patches/RoleAssignmentPatch.cs
+++ b/TheOtherRoles/Patches/RoleAssignmentPatch.cs
@@ -72,6 +72,7 @@ namespace TheOtherRoles.Patches {
             impSettings.Add((byte)RoleId.Cleaner, CustomOptionHolder.cleanerSpawnRate.getSelection());
             impSettings.Add((byte)RoleId.Warlock, CustomOptionHolder.warlockSpawnRate.getSelection());
             impSettings.Add((byte)RoleId.BountyHunter, CustomOptionHolder.bountyHunterSpawnRate.getSelection());
+            impSettings.Add((byte)RoleId.BadGuesser, CustomOptionHolder.badGuesserSpawnRate.getSelection());
 
             neutralSettings.Add((byte)RoleId.Jester, CustomOptionHolder.jesterSpawnRate.getSelection());
             neutralSettings.Add((byte)RoleId.Arsonist, CustomOptionHolder.arsonistSpawnRate.getSelection());
@@ -90,6 +91,7 @@ namespace TheOtherRoles.Patches {
             crewSettings.Add((byte)RoleId.Hacker, CustomOptionHolder.hackerSpawnRate.getSelection());
             crewSettings.Add((byte)RoleId.Tracker, CustomOptionHolder.trackerSpawnRate.getSelection());
             crewSettings.Add((byte)RoleId.Snitch, CustomOptionHolder.snitchSpawnRate.getSelection());
+            crewSettings.Add((byte)RoleId.GoodGuesser, CustomOptionHolder.goodGuesserSpawnRate.getSelection());
             if (impostors.Count > 1) {
                 // Only add Spy if more than 1 impostor as the spy role is otherwise useless
                 crewSettings.Add((byte)RoleId.Spy, CustomOptionHolder.spySpawnRate.getSelection());
@@ -147,13 +149,6 @@ namespace TheOtherRoles.Patches {
                 data.impSettings.Add((byte)RoleId.Mini, CustomOptionHolder.miniSpawnRate.getSelection());
             } else if (data.crewmates.Count > 0 && data.maxCrewmateRoles > 0) {
                 data.crewSettings.Add((byte)RoleId.Mini, CustomOptionHolder.miniSpawnRate.getSelection());
-            }
-
-            // Assign Guesser (chance to be impostor based on setting)
-            if (data.impostors.Count > 0 && data.maxImpostorRoles > 0 &&  rnd.Next(1, 101) <= CustomOptionHolder.guesserIsImpGuesserRate.getSelection() * 10) {
-                data.impSettings.Add((byte)RoleId.Guesser, CustomOptionHolder.guesserSpawnRate.getSelection());
-            } else if (data.crewmates.Count > 0 && data.maxCrewmateRoles > 0) {
-                data.crewSettings.Add((byte)RoleId.Guesser, CustomOptionHolder.guesserSpawnRate.getSelection());
             }
         }
 

--- a/TheOtherRoles/Patches/UpdatePatch.cs
+++ b/TheOtherRoles/Patches/UpdatePatch.cs
@@ -114,8 +114,10 @@ namespace TheOtherRoles.Patches {
                 setPlayerNameColor(SecurityGuard.securityGuard, SecurityGuard.color);
             } else if (Arsonist.arsonist != null && Arsonist.arsonist == PlayerControl.LocalPlayer) {
                 setPlayerNameColor(Arsonist.arsonist, Arsonist.color);
-            } else if (Guesser.guesser != null && Guesser.guesser == PlayerControl.LocalPlayer) {
-                setPlayerNameColor(Guesser.guesser, Guesser.guesser.Data.IsImpostor ? Palette.ImpostorRed : Guesser.color);
+            } else if (BadGuesser.guesser != null && BadGuesser.guesser == PlayerControl.LocalPlayer) {
+                setPlayerNameColor(BadGuesser.guesser, BadGuesser.guesser.Data.IsImpostor ? Palette.ImpostorRed : BadGuesser.color);
+            } else if (GoodGuesser.guesser != null && GoodGuesser.guesser == PlayerControl.LocalPlayer) {
+                setPlayerNameColor(GoodGuesser.guesser, GoodGuesser.color);
             }
 
             // No else if here, as a Lover of team Jackal needs the colors
@@ -133,7 +135,7 @@ namespace TheOtherRoles.Patches {
             }
 
             // Crewmate roles with no changes: Mini
-            // Impostor roles with no changes: Morphling, Camouflager, Vampire, Godfather, Eraser, Janitor, Cleaner, Warlock, BountyHunter and Mafioso
+            // Impostor roles with no changes: Morphling, Camouflager, Vampire, Godfather, Eraser, Janitor, Cleaner, Warlock, BountyHunter, Mafioso
         }
 
         static void setNameTags() {

--- a/TheOtherRoles/RoleInfo.cs
+++ b/TheOtherRoles/RoleInfo.cs
@@ -54,8 +54,8 @@ namespace TheOtherRoles
         public static RoleInfo spy = new RoleInfo("Spy", Spy.color, "Confuse the <color=#FF1919FF>Impostors</color>", "Confuse the Impostors", RoleId.Spy);
         public static RoleInfo securityGuard = new RoleInfo("Security Guard", SecurityGuard.color, "Seal vents and place cameras", "Seal vents and place cameras", RoleId.SecurityGuard);
         public static RoleInfo arsonist = new RoleInfo("Arsonist", Arsonist.color, "Let them burn", "Let them burn", RoleId.Arsonist);
-        public static RoleInfo goodGuesser = new RoleInfo("Nice Guesser", Guesser.color, "Guess and shoot", "Guess and shoot", RoleId.Guesser);
-        public static RoleInfo badGuesser = new RoleInfo("Evil Guesser", Palette.ImpostorRed, "Guess and shoot", "Guess and shoot", RoleId.Guesser);
+        public static RoleInfo goodGuesser = new RoleInfo("Nice Guesser", GoodGuesser.color, "Guess and shoot", "Guess and shoot", RoleId.GoodGuesser);
+        public static RoleInfo badGuesser = new RoleInfo("Evil Guesser", Palette.ImpostorRed, "Guess and shoot", "Guess and shoot", RoleId.BadGuesser);
         public static RoleInfo impostor = new RoleInfo("Impostor", Palette.ImpostorRed, Helpers.cs(Palette.ImpostorRed, "Sabotage and kill everyone"), "Sabotage and kill everyone", RoleId.Impostor);
         public static RoleInfo crewmate = new RoleInfo("Crewmate", Color.white, "Find the Impostors", "Find the Impostors", RoleId.Crewmate);
         public static RoleInfo lover = new RoleInfo("Lover", Lovers.color, $"You are in love", $"You are in love", RoleId.Lover);
@@ -98,7 +98,8 @@ namespace TheOtherRoles
             snitch,
             spy,
             securityGuard,
-            bountyHunter
+            bountyHunter,
+            chamaleon
         };
 
         public static List<RoleInfo> getRoleInfoForPlayer(PlayerControl p) {
@@ -136,8 +137,10 @@ namespace TheOtherRoles
             if (p == Spy.spy) infos.Add(spy);
             if (p == SecurityGuard.securityGuard) infos.Add(securityGuard);
             if (p == Arsonist.arsonist) infos.Add(arsonist);
-            if (p == Guesser.guesser) infos.Add(p.Data.IsImpostor ? badGuesser : goodGuesser);
+            if (p == BadGuesser.guesser) infos.Add(badGuesser);
+            if (p == GoodGuesser.guesser) infos.Add(goodGuesser);
             if (p == BountyHunter.bountyHunter) infos.Add(bountyHunter);
+            if (p == Roles.Chamaleon.chamaleon) infos.Add(chamaleon);
 
             // Default roles
             if (infos.Count == 0 && p.Data.IsImpostor) infos.Add(impostor); // Just Impostor

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -51,7 +51,8 @@ namespace TheOtherRoles
             Warlock.clearAndReload();
             SecurityGuard.clearAndReload();
             Arsonist.clearAndReload();
-            Guesser.clearAndReload();
+            BadGuesser.clearAndReload();
+            GoodGuesser.clearAndReload();
             BountyHunter.clearAndReload();
         }
 
@@ -935,9 +936,9 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Guesser {
+    public static class BadGuesser {
         public static PlayerControl guesser;
-        public static Color color = new Color32(255, 255, 0, byte.MaxValue);
+        public static Color color = Palette.ImpostorRed;
         private static Sprite targetSprite;
 
         public static int remainingShots = 2;
@@ -951,7 +952,28 @@ namespace TheOtherRoles
         public static void clearAndReload() {
             guesser = null;
             
-            remainingShots = Mathf.RoundToInt(CustomOptionHolder.guesserNumberOfShots.getFloat());
+            remainingShots = Mathf.RoundToInt(CustomOptionHolder.badGuesserNumberOfShots.getFloat());
+        }
+    }
+
+
+    public static class GoodGuesser {
+        public static PlayerControl guesser;
+        public static Color color = new Color32(255, 255, 0, byte.MaxValue);
+        private static Sprite targetSprite;
+
+        public static int remainingShots = 2;
+
+        public static Sprite getTargetSprite() {
+            if(targetSprite) return targetSprite;
+            targetSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.TargetIcon.png", 150f);
+            return targetSprite;
+        }
+
+        public static void clearAndReload() {
+            guesser = null;
+
+            remainingShots = Mathf.RoundToInt(CustomOptionHolder.badGuesserNumberOfShots.getFloat());
         }
     }
 

--- a/TheOtherRoles/TheOtherRoles.csproj
+++ b/TheOtherRoles/TheOtherRoles.csproj
@@ -19,8 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(AmongUsLatest)/BepInEx/core/*.dll"/>
-        <Reference Include="$(AmongUsLatest)/BepInEx/unhollowed/*.dll"/>
+        <Reference Include="$(AmongUsLatest)/BepInEx/core/*.dll" />
+        <Reference Include="$(AmongUsLatest)/BepInEx/unhollowed/*.dll" />
     </ItemGroup>
 
     <Target Name="CopyCustomContent" AfterTargets="AfterBuild">


### PR DESCRIPTION
Seperated the "Guesser" Role into two unique roles: "Evil Guesser" and "Nice Guesser".

Each can be configured in the menu.

- chance of being spawed
- number of shoots

There is no more option/chance that allows the guesser to be evil **or** nice.