### PR TITLE
Guessing Lover meeting room UX bug

### DIFF
--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -683,7 +683,7 @@ namespace TheOtherRoles
             PlayerControl target = Helpers.playerById(playerId);
             if (target == null) return;
             target.Exiled();
-            PlayerControl partner = target.getPartner(); // Lover check
+            PlayerControl partner = target.getSuicidePartner(); // Lover check
             byte partnerId = partner != null ? partner.PlayerId : playerId;
             Guesser.remainingShots = Mathf.Max(0, Guesser.remainingShots - 1);
             if (Constants.ShouldPlaySfx()) SoundManager.Instance.PlaySound(target.KillSfx, false, 0.8f);

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -364,6 +364,12 @@ namespace TheOtherRoles
                 return lover1;
             return null;
         }
+
+        public static PlayerControl getSuicidePartner(this PlayerControl player) {
+            if (bothDie) return null;
+
+            return player.getPartner();
+        }
     }
 
     public static class Seer {


### PR DESCRIPTION
When a guesser correctly guesses a Lover, both Lovers appear to die on the meeting screen. This happens even if `bothDie` isn't set, which can be really confusing. Existing behavior is the linked lover does not die in this case. It's just a UX glitch in the meeting.

This PR adds a method that only returns the lover partner if they are linked. `guesserShoot` is updated to use that method instead when determining which kill animations to show.