### PR TITLE
[RFC] Add the new role, Madmate

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -175,6 +175,7 @@ namespace TheOtherRoles
                     byte targetId = 0;
                     if ((Sheriff.currentTarget.Data.IsImpostor && (Sheriff.currentTarget != Mini.mini || Mini.isGrownUp())) || 
                         (Sheriff.spyCanDieToSheriff && Spy.spy == Sheriff.currentTarget) ||
+                        (Sheriff.madmateCanDieToSheriff && Madmate.madmate == Sheriff.currentTarget) ||
                         (Sheriff.canKillNeutrals && (Arsonist.arsonist == Sheriff.currentTarget || Jester.jester == Sheriff.currentTarget)) ||
                         (Jackal.jackal == Sheriff.currentTarget || Sidekick.sidekick == Sheriff.currentTarget)) {
                         targetId = Sheriff.currentTarget.PlayerId;

--- a/TheOtherRoles/CustomOptions.cs
+++ b/TheOtherRoles/CustomOptions.cs
@@ -166,6 +166,12 @@ namespace TheOtherRoles {
         public static CustomOption baitHighlightAllVents;
         public static CustomOption baitReportDelay;
 
+        public static CustomOption madmateSpawnRate;
+        public static CustomOption madmateCanDieToSheriff;
+        public static CustomOption madmateCanEnterVents;
+        public static CustomOption madmateHasImpostorVision;
+        public static CustomOption madmateCanSabotage;
+
         public static CustomOption maxNumberOfMeetings;
         public static CustomOption blockSkippingInEmergencyMeetings;
         public static CustomOption noVoteIsSelfVote;
@@ -339,6 +345,12 @@ namespace TheOtherRoles {
             baitSpawnRate = CustomOption.Create(330, cs(Bait.color, "Bait"), rates, null, true);
             baitHighlightAllVents = CustomOption.Create(331, "Highlight All Vents If A Vent Is Occupied", false, baitSpawnRate);
             baitReportDelay = CustomOption.Create(332, "Bait Report Delay", 0f, 0f, 10f, 1f, baitSpawnRate);
+
+            madmateSpawnRate = CustomOption.Create(360, cs(Madmate.color, "Madmate"), rates, null, true);
+            madmateCanDieToSheriff = CustomOption.Create(361, "Madmate Can Die To Sheriff", false, madmateSpawnRate);
+            madmateCanEnterVents = CustomOption.Create(362, "Madmate Can Enter Vents", false, madmateSpawnRate);
+            madmateHasImpostorVision = CustomOption.Create(363, "Madmate Has Impostor Vision", false, madmateSpawnRate);
+            madmateCanSabotage = CustomOption.Create(364, "Madmate Can Sabotage", false, madmateSpawnRate);
 
             // Other options
             maxNumberOfMeetings = CustomOption.Create(3, "Number Of Meetings (excluding Mayor meeting)", 10, 0, 15, 1, null, true);
@@ -658,7 +670,7 @@ namespace TheOtherRoles {
             var hudString = sb.ToString();
 
             int defaultSettingsLines = 19;
-            int roleSettingsLines = defaultSettingsLines + 35;
+            int roleSettingsLines = defaultSettingsLines + 36;
             int detailedSettingsP1 = roleSettingsLines + 37;
             int detailedSettingsP2 = detailedSettingsP1 + 38;
             int end1 = hudString.TakeWhile(c => (defaultSettingsLines -= (c == '\n' ? 1 : 0)) > 0).Count();

--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -191,7 +191,7 @@ namespace TheOtherRoles {
         }
 
         public static bool hasFakeTasks(this PlayerControl player) {
-            return (player == Jester.jester || player == Jackal.jackal || player == Sidekick.sidekick || player == Arsonist.arsonist || Jackal.formerJackals.Contains(player));
+            return (player == Madmate.madmate || player == Jester.jester || player == Jackal.jackal || player == Sidekick.sidekick || player == Arsonist.arsonist || Jackal.formerJackals.Contains(player));
         }
 
         public static bool canBeErased(this PlayerControl player) {

--- a/TheOtherRoles/Patches/EndGamePatch.cs
+++ b/TheOtherRoles/Patches/EndGamePatch.cs
@@ -72,6 +72,7 @@ namespace TheOtherRoles.Patches {
             if (Sidekick.sidekick != null) notWinners.Add(Sidekick.sidekick);
             if (Jackal.jackal != null) notWinners.Add(Jackal.jackal);
             if (Arsonist.arsonist != null) notWinners.Add(Arsonist.arsonist);
+            if (Madmate.madmate != null) notWinners.Add(Madmate.madmate);
             notWinners.AddRange(Jackal.formerJackals);
 
             List<WinningPlayerData> winnersToRemove = new List<WinningPlayerData>();
@@ -153,6 +154,15 @@ namespace TheOtherRoles.Patches {
                     wpdFormerJackal.IsImpostor = false; 
                     TempData.winners.Add(wpdFormerJackal);
                 }
+            } else {
+              // Madmate wins if team impostors wins
+              foreach (WinningPlayerData winner in TempData.winners) {
+                  if (winner.IsImpostor) {
+                    WinningPlayerData wpd = new WinningPlayerData(Madmate.madmate.Data);
+                    TempData.winners.Add(wpd);
+                    break;
+                  }
+              }
             }
 
             // Reset Settings

--- a/TheOtherRoles/Patches/RoleAssignmentPatch.cs
+++ b/TheOtherRoles/Patches/RoleAssignmentPatch.cs
@@ -91,6 +91,7 @@ namespace TheOtherRoles.Patches {
             crewSettings.Add((byte)RoleId.Tracker, CustomOptionHolder.trackerSpawnRate.getSelection());
             crewSettings.Add((byte)RoleId.Snitch, CustomOptionHolder.snitchSpawnRate.getSelection());
             crewSettings.Add((byte)RoleId.Bait, CustomOptionHolder.baitSpawnRate.getSelection());
+            crewSettings.Add((byte)RoleId.Madmate, CustomOptionHolder.madmateSpawnRate.getSelection());
             if (impostors.Count > 1) {
                 // Only add Spy if more than 1 impostor as the spy role is otherwise useless
                 crewSettings.Add((byte)RoleId.Spy, CustomOptionHolder.spySpawnRate.getSelection());

--- a/TheOtherRoles/Patches/ShipStatusPatch.cs
+++ b/TheOtherRoles/Patches/ShipStatusPatch.cs
@@ -22,7 +22,8 @@ namespace TheOtherRoles.Patches {
             else if (player.IsImpostor
                 || (Jackal.jackal != null && Jackal.jackal.PlayerId == player.PlayerId && Jackal.hasImpostorVision)
                 || (Sidekick.sidekick != null && Sidekick.sidekick.PlayerId == player.PlayerId && Sidekick.hasImpostorVision)
-                || (Spy.spy != null && Spy.spy.PlayerId == player.PlayerId && Spy.hasImpostorVision)) // Impostor, Jackal/Sidekick or Spy with Impostor vision
+                || (Spy.spy != null && Spy.spy.PlayerId == player.PlayerId && Spy.hasImpostorVision)
+                || (Madmate.madmate != null && Madmate.madmate.PlayerId == player.PlayerId && Madmate.hasImpostorVision)) // Impostor, Jackal/Sidekick, Spy, or Madmate with Impostor vision
                 __result = __instance.MaxLightRadius * PlayerControl.GameOptions.ImpostorLightMod;
             else if (Lighter.lighter != null && Lighter.lighter.PlayerId == player.PlayerId && Lighter.lighterTimer > 0f) // if player is Lighter and Lighter has his ability active
                 __result = Mathf.Lerp(__instance.MaxLightRadius * Lighter.lighterModeLightsOffVision, __instance.MaxLightRadius * Lighter.lighterModeLightsOnVision, num);

--- a/TheOtherRoles/Patches/UpdatePatch.cs
+++ b/TheOtherRoles/Patches/UpdatePatch.cs
@@ -118,6 +118,8 @@ namespace TheOtherRoles.Patches {
                 setPlayerNameColor(Guesser.guesser, Guesser.guesser.Data.IsImpostor ? Palette.ImpostorRed : Guesser.color);
             } else if (Bait.bait != null && Bait.bait == PlayerControl.LocalPlayer) {
                 setPlayerNameColor(Bait.bait, Bait.color);
+            } else if (Madmate.madmate != null && Madmate.madmate == PlayerControl.LocalPlayer) {
+                setPlayerNameColor(Madmate.madmate, Madmate.color);
             }
 
             // No else if here, as a Lover of team Jackal needs the colors

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -48,6 +48,7 @@ namespace TheOtherRoles
         Guesser,
         BountyHunter,
         Bait,
+        Madmate,
         Crewmate,
         Impostor
     }
@@ -236,6 +237,9 @@ namespace TheOtherRoles
                         break;
                     case RoleId.Bait:
                         Bait.bait = player;
+                        break;
+                    case RoleId.Madmate:
+                        Madmate.madmate = player;
                         break;
                     }
                 }
@@ -426,6 +430,8 @@ namespace TheOtherRoles
                 Guesser.guesser = oldShifter;
             if (Bait.bait != null && Bait.bait == player)
                 Bait.bait = oldShifter;
+            if (Madmate.madmate != null && Madmate.madmate == player)
+                Madmate.madmate = oldShifter;
             
             // Set cooldowns to max for both players
             if (PlayerControl.LocalPlayer == oldShifter || PlayerControl.LocalPlayer == player)
@@ -558,6 +564,7 @@ namespace TheOtherRoles
             if (player == Spy.spy) Spy.clearAndReload();
             if (player == SecurityGuard.securityGuard) SecurityGuard.clearAndReload();
             if (player == Bait.bait) Bait.clearAndReload();
+            if (player == Madmate.madmate) Madmate.clearAndReload();
 
             // Impostor roles
             if (player == Morphling.morphling) Morphling.clearAndReload();

--- a/TheOtherRoles/RoleInfo.cs
+++ b/TheOtherRoles/RoleInfo.cs
@@ -57,6 +57,7 @@ namespace TheOtherRoles
         public static RoleInfo goodGuesser = new RoleInfo("Nice Guesser", Guesser.color, "Guess and shoot", "Guess and shoot", RoleId.Guesser);
         public static RoleInfo badGuesser = new RoleInfo("Evil Guesser", Palette.ImpostorRed, "Guess and shoot", "Guess and shoot", RoleId.Guesser);
         public static RoleInfo bait = new RoleInfo("Bait", Bait.color, "Bait your enemies", "Bait your enemies", RoleId.Bait);
+        public static RoleInfo madmate = new RoleInfo("Madmate", Madmate.color, "Help the <color=#FF1919FF>Impostors</color>", "Help the Impostors", RoleId.Madmate);
         public static RoleInfo impostor = new RoleInfo("Impostor", Palette.ImpostorRed, Helpers.cs(Palette.ImpostorRed, "Sabotage and kill everyone"), "Sabotage and kill everyone", RoleId.Impostor);
         public static RoleInfo crewmate = new RoleInfo("Crewmate", Color.white, "Find the Impostors", "Find the Impostors", RoleId.Crewmate);
         public static RoleInfo lover = new RoleInfo("Lover", Lovers.color, $"You are in love", $"You are in love", RoleId.Lover);
@@ -100,7 +101,8 @@ namespace TheOtherRoles
             spy,
             securityGuard,
             bountyHunter,
-            bait
+            bait,
+            madmate
         };
 
         public static List<RoleInfo> getRoleInfoForPlayer(PlayerControl p) {
@@ -141,6 +143,7 @@ namespace TheOtherRoles
             if (p == Guesser.guesser) infos.Add(p.Data.IsImpostor ? badGuesser : goodGuesser);
             if (p == BountyHunter.bountyHunter) infos.Add(bountyHunter);
             if (p == Bait.bait) infos.Add(bait);
+            if (p == Madmate.madmate) infos.Add(madmate);
 
             // Default roles
             if (infos.Count == 0 && p.Data.IsImpostor) infos.Add(impostor); // Just Impostor

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -54,6 +54,7 @@ namespace TheOtherRoles
             Guesser.clearAndReload();
             BountyHunter.clearAndReload();
             Bait.clearAndReload();
+            Madmate.clearAndReload();
         }
 
         public static class Jester {
@@ -144,6 +145,7 @@ namespace TheOtherRoles
             public static float cooldown = 30f;
             public static bool canKillNeutrals = false;
             public static bool spyCanDieToSheriff = false;
+            public static bool madmateCanDieToSheriff = false;
 
             public static PlayerControl currentTarget;
 
@@ -153,6 +155,7 @@ namespace TheOtherRoles
                 cooldown = CustomOptionHolder.sheriffCooldown.getFloat();
                 canKillNeutrals = CustomOptionHolder.sheriffCanKillNeutrals.getBool();
                 spyCanDieToSheriff = CustomOptionHolder.spyCanDieToSheriff.getBool();
+                madmateCanDieToSheriff = CustomOptionHolder.madmateCanDieToSheriff.getBool();
             }
         }
 
@@ -1024,6 +1027,22 @@ namespace TheOtherRoles
             reported = false;
             highlightAllVents = CustomOptionHolder.baitHighlightAllVents.getBool();
             reportDelay = CustomOptionHolder.baitReportDelay.getFloat();
+        }
+    }
+
+    public static class Madmate {
+        public static PlayerControl madmate;
+        public static Color color = Palette.ImpostorRed;
+
+        public static bool canEnterVents = false;
+        public static bool hasImpostorVision = false;
+        public static bool canSabotage = false;
+
+        public static void clearAndReload() {
+            madmate = null;
+            canEnterVents = CustomOptionHolder.madmateCanEnterVents.getBool();
+            hasImpostorVision = CustomOptionHolder.madmateHasImpostorVision.getBool();
+            canSabotage = CustomOptionHolder.madmateCanSabotage.getBool();
         }
     }
 }


### PR DESCRIPTION
Hi developers,
I've implemented a new role. The original idea is from The Werewolves (Party game) and [the other mod](https://au.libhalt.net/#spy) (Sorry, the site is written in Japanese)
Could I have comments about the the new role and my implementation?
Thank you.

# Madmate

The Madmate is the new role for the mod of Among Us, TheOtherRoles.
The idea is originally from Are You a Werewolf? and the name origin is [the other mod](https://au.libhalt.net/#madmate) (Japanese only)

## **Team: Impostor**

1. Except for the win condition, the Madmate is a Crewmate.
2. The Madmate wins if the team Impostors wins.
3. The Madmate/Impostors does/do not know who are/is the Impostors/Madmate.
4. The Madmate has fake tasks instead of real one.
5. The Madmate cannot fix light out sabotage.

### Game Options
| Name | Description
|----------|:-------------:|
| Madmate Spawn Chance |
| Madmate Can Die To Sheriff |
| Madmate Can Enter Vents | Allow the Madmate to enter/exit vents (but not actually move to connected vents)
| Madmate Has Impostor Vision | Give the Madmate the same vision as the Impostors have
| Madmate Can sabotage | Option to allow the Madmate to sabotage
| Madmate Can fix comm | Option to allow the Madmate to fix comm sabotage
-----------------------

## Configuration

The Madmate is a Crewmate role.
Please increment the minimum and maximum number of crewmate roles to see the Madmate in a play.