### PR TITLE
Fix Evil Guesser cannot guess

### DIFF
--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -1031,7 +1031,7 @@ namespace TheOtherRoles
 
         public static int remainingShots(byte playerId, bool shoot = false) {
             int remainingShots = remainingShotsEvilGuesser;
-            if (niceGuesser.PlayerId == playerId) {
+            if (niceGuesser != null && niceGuesser.PlayerId == playerId) {
                 remainingShots = remainingShotsNiceGuesser;
                 if (shoot) remainingShotsNiceGuesser = Mathf.Max(0, remainingShotsNiceGuesser - 1);
             } else if (shoot) {


### PR DESCRIPTION
Fix #264 

Add null check to avoid for NullReferenceException in `Guesser.remainingShots`.

I've faced the error message below and fixed it.

```
[Error  :    Detour] System.NullReferenceException: Object reference not set to an instance of an object
  at TheOtherRoles.Guesser.remainingShots (System.Byte playerId, System.Boolean shoot) [0x00006] in <abe2ffeeb45c49cca92a9255671b5e1e>:0 
  at TheOtherRoles.Patches.MeetingHudPatch.populateButtonsPostfix (MeetingHud __instance) [0x00354] in <abe2ffeeb45c49cca92a9255671b5e1e>:0 
  at TheOtherRoles.Patches.MeetingHudPatch+MeetingDeserializePatch.Postfix (MeetingHud __instance, Hazel.MessageReader reader, System.Boolean initialState) [0x00003] in <abe2ffeeb45c49cca92a9255671b5e1e>:0 
  at (wrapper dynamic-method) MeetingHud.DMD<MeetingHud::Deserialize>(MeetingHud,Hazel.MessageReader,bool)
  at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.(il2cpp -> managed) Deserialize(intptr,intptr,bool,UnhollowerBaseLib.Runtime.Il2CppMethodInfo*)
```

