### PR TITLE
Jester vision

### DIFF
--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -62,6 +62,8 @@ namespace TheOtherRoles {
 
         public static CustomOption jesterSpawnRate;
         public static CustomOption jesterCanCallEmergency;
+        public static CustomOption jesterVision;
+        public static CustomOption jesterHasImpostorVision;
 
         public static CustomOption arsonistSpawnRate;
         public static CustomOption arsonistCooldown;
@@ -308,6 +310,12 @@ namespace TheOtherRoles {
 
             jesterSpawnRate = CustomOption.Create(60, cs(Jester.color, "Jester"), rates, null, true);
             jesterCanCallEmergency = CustomOption.Create(61, "Jester can call emergency meeting", true, jesterSpawnRate);
+			
+			// Credit JustASysAdmin aka EvilScum
+			// Using 6XX ids to prevent issues with the master branch.
+			// Code to add vision is in the ShipStatus patch.
+            jesterVision = CustomOption.Create(601, "Jester Vision", 1f, 0.25f, 3f, 0.25f, jesterSpawnRate);
+            jesterHasImpostorVision = CustomOption.Create(602, "Jester Has Impostor Vision", false, jesterSpawnRate);
 
             arsonistSpawnRate = CustomOption.Create(290, cs(Arsonist.color, "Arsonist"), rates, null, true);
             arsonistCooldown = CustomOption.Create(291, "Arsonist Cooldown", 12.5f, 2.5f, 60f, 2.5f, arsonistSpawnRate);

--- a/TheOtherRoles/Patches/ShipStatusPatch.cs
+++ b/TheOtherRoles/Patches/ShipStatusPatch.cs
@@ -22,7 +22,9 @@ namespace TheOtherRoles.Patches {
             else if (player.Role.IsImpostor
                 || (Jackal.jackal != null && Jackal.jackal.PlayerId == player.PlayerId && Jackal.hasImpostorVision)
                 || (Sidekick.sidekick != null && Sidekick.sidekick.PlayerId == player.PlayerId && Sidekick.hasImpostorVision)
-                || (Spy.spy != null && Spy.spy.PlayerId == player.PlayerId && Spy.hasImpostorVision)) // Impostor, Jackal/Sidekick or Spy with Impostor vision
+                || (Spy.spy != null && Spy.spy.PlayerId == player.PlayerId && Spy.hasImpostorVision) // Impostor, Jackal/Sidekick or Spy with Impostor vision
+                || (Jester.jester != null && Jester.jester.PlayerId == player.PlayerId && Jester.hasImpostorVision)) // Also Jester with Impostor vision
+
                 __result = __instance.MaxLightRadius * PlayerControl.GameOptions.ImpostorLightMod;
             else if (Lighter.lighter != null && Lighter.lighter.PlayerId == player.PlayerId && Lighter.lighterTimer > 0f) // if player is Lighter and Lighter has his ability active
                 __result = Mathf.Lerp(__instance.MaxLightRadius * Lighter.lighterModeLightsOffVision, __instance.MaxLightRadius * Lighter.lighterModeLightsOnVision, num);
@@ -34,6 +36,8 @@ namespace TheOtherRoles.Patches {
             }
             else if (Lawyer.lawyer != null && Lawyer.lawyer.PlayerId == player.PlayerId) // if player is Lighter and Lighter has his ability active
                 __result = Mathf.Lerp(__instance.MinLightRadius, __instance.MaxLightRadius * Lawyer.vision, num);
+            else if (Jester.jester != null && Jester.jester.PlayerId == player.PlayerId) // if player is Lighter and Lighter has his ability active
+                __result = Mathf.Lerp(__instance.MinLightRadius, __instance.MaxLightRadius * Jester.vision, num);
             else
                 __result = Mathf.Lerp(__instance.MinLightRadius, __instance.MaxLightRadius, num) * PlayerControl.GameOptions.CrewLightMod;
             return false;

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -67,11 +67,20 @@ namespace TheOtherRoles
 
             public static bool triggerJesterWin = false;
             public static bool canCallEmergency = true;
-
+			
+			// Adding in options to give Jester extra vision.
+			public static bool hasImpostorVision = false;
+			public static float vision = 1f;
+			
+			
             public static void clearAndReload() {
                 jester = null;
                 triggerJesterWin = false;
                 canCallEmergency = CustomOptionHolder.jesterCanCallEmergency.getBool();
+				
+				// Set the options needed for jester vision from the CustomOptionHolder
+				vision = CustomOptionHolder.jesterVision.getFloat();
+				hasImpostorVision = CustomOptionHolder.jesterHasImpostorVision.getBool();
             }
         }
 


### PR DESCRIPTION
Adds in an option to either give the Jester their own vision, or impostor vision.
![image](https://user-images.githubusercontent.com/97370685/151051654-628c130b-8fbf-4c7a-975b-2c24511d0e85.png)
Since it seems pretty popular, I went ahead and actually implemented it.

In all honesty it could be cleaned up a touch. Main think I'm thinking of it reversing the has imp vision to has crew vision, which would then show the vision selector. 