### PR TITLE
Fix the report button triggering the handcuffs, even when no body is nearby.

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -160,7 +160,7 @@ namespace TheOtherRoles
                 // Vent Button if enabled
                 if (PlayerControl.LocalPlayer.roleCanUseVents()) addReplacementHandcuffedButton(arsonistButton, new Vector3(-1.8f, 1f, 0), couldUse: () => { return HudManager.Instance.ImpostorVentButton.currentTarget != null; });
                 // Report Button
-                addReplacementHandcuffedButton(arsonistButton, new Vector3(-0.9f, -0.06f, 0), () => { return HudManager.Instance.ReportButton.enabled; });
+                addReplacementHandcuffedButton(arsonistButton, new Vector3(-0.9f, -0.06f, 0), () => { return HudManager.Instance.ReportButton.graphic.color == Palette.EnabledColor; });
             }
             else if (!handcuffed && deputyHandcuffedButtons.ContainsKey(PlayerControl.LocalPlayer.PlayerId))  // Reset to original. Disables the replacements, enables the original buttons.
             {

--- a/TheOtherRoles/Patches/UsablesPatch.cs
+++ b/TheOtherRoles/Patches/UsablesPatch.cs
@@ -169,7 +169,7 @@ namespace TheOtherRoles.Patches {
     [HarmonyPatch(typeof(ReportButton), nameof(ReportButton.DoClick))]
     class ReportButtonDoClickPatch {
         public static bool Prefix(ReportButton __instance) {
-            if (__instance.isActiveAndEnabled && Deputy.handcuffedPlayers.Contains(PlayerControl.LocalPlayer.PlayerId)) Deputy.setHandcuffedKnows();
+            if (__instance.isActiveAndEnabled && Deputy.handcuffedPlayers.Contains(PlayerControl.LocalPlayer.PlayerId) && __instance.graphic.color == Palette.EnabledColor) Deputy.setHandcuffedKnows();
             return !Deputy.handcuffedKnows.ContainsKey(PlayerControl.LocalPlayer.PlayerId);
         }
     }


### PR DESCRIPTION
Fixes eisbison/theotherroles#295

The report button has a strange behavior, where its `enabled` property is inconsistent. We can use the same workaround as for the vulture, which is to use the `graphic.color == Palette.EnabledColor` instead.