### PR TITLE
MBF: Automatically pull Version and AssemblyName into Main.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/tasks.json
 TODO
 .DS_Store
+obj/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/TheOtherRoles/Main.cs
+++ b/TheOtherRoles/Main.cs
@@ -16,14 +16,13 @@ using TheOtherRoles.Modules;
 
 namespace TheOtherRoles
 {
-    [BepInPlugin(Id, "The Other Roles", VersionString)]
+    [BepInPlugin(Id, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
     [BepInProcess("Among Us.exe")]
     public class TheOtherRolesPlugin : BasePlugin
     {
         public const string Id = "me.eisbison.theotherroles";
-        public const string VersionString = "4.0.0";
-
-        public static System.Version Version = System.Version.Parse(VersionString);
+        public static string VersionString = PluginInfo.PLUGIN_VERSION;
+        public static System.Version Version = System.Version.Parse(PluginInfo.PLUGIN_VERSION);
         internal static BepInEx.Logging.ManualLogSource Logger;
 
         public Harmony Harmony { get; } = new Harmony(Id);

--- a/TheOtherRoles/TheOtherRoles.csproj
+++ b/TheOtherRoles/TheOtherRoles.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
+        <AssemblyName>TheOtherRoles</AssemblyName>
         <Version>4.0.0</Version>
         <Description>TheOtherRoles</Description>
         <Authors>Eisbison</Authors>
@@ -25,6 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Remove="Resources\Blood1.png" />
       <None Remove="Resources\Blood2.png" />
       <None Remove="Resources\Blood3.png" />
@@ -32,6 +37,6 @@
 
     <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
         <Message Text="Second occurrence" />
-        <Copy SourceFiles="$(ProjectDir)\bin\$(Configuration)\netstandard2.1\TheOtherRoles.dll" DestinationFolder="$(AmongUsLatest)/BepInEx/plugins/" />
+        <Copy SourceFiles="$(ProjectDir)\bin\$(Configuration)\netstandard2.1\$(AssemblyName).dll" DestinationFolder="$(AmongUsLatest)/BepInEx/plugins/" />
     </Target>
 </Project>


### PR DESCRIPTION
Added BepInEx.PluginInfoProps so that Version and AssemblyName in TheOtherRoles.csproj can be called in Main.cs.  Prevents the need to type it in twice. (Also makes using CI to add a build number when testing much easier).