### PR TITLE
MBF: Dynamic Impostor Count & Dynamic Vulture Num Bodies to Win.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/tasks.json
 TODO
 .DS_Store
+bin/
+obj/

--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -279,6 +279,8 @@ namespace TheOtherRoles {
         public static CustomOption dynamicMapEnablePolus;
         public static CustomOption dynamicMapEnableAirShip;
 
+        public static CustomOption dynamicImpostor;
+
 
         internal static Dictionary<byte, byte[]> blockedRolePairings = new Dictionary<byte, byte[]>();
 
@@ -392,7 +394,7 @@ namespace TheOtherRoles {
 
             vultureSpawnRate = CustomOption.Create(340, Types.Neutral, cs(Vulture.color, "Vulture"), rates, null, true);
             vultureCooldown = CustomOption.Create(341, Types.Neutral, "Vulture Cooldown", 15f, 10f, 60f, 2.5f, vultureSpawnRate);
-            vultureNumberToWin = CustomOption.Create(342, Types.Neutral, "Number Of Corpses Needed To Be Eaten", 4f, 1f, 10f, 1f, vultureSpawnRate);
+            // vultureNumberToWin = CustomOption.Create(342, Types.Neutral, "Number Of Corpses Needed To Be Eaten", 4f, 1f, 10f, 1f, vultureSpawnRate);
             vultureCanUseVents = CustomOption.Create(343, Types.Neutral, "Vulture Can Use Vents", true, vultureSpawnRate);
             vultureShowArrows = CustomOption.Create(344, Types.Neutral, "Show Arrows Pointing Towards The Corpses", true, vultureSpawnRate);
 
@@ -557,6 +559,7 @@ namespace TheOtherRoles {
             allowParallelMedBayScans = CustomOption.Create(7, Types.General, "Allow Parallel MedBay Scans", false);
             shieldFirstKill = CustomOption.Create(8, Types.General, "Shield Last Game First Kill", false);
 
+            dynamicImpostor = CustomOption.Create(9, Types.General, "Dynamic Impostor Count", true, null, true);
             dynamicMap = CustomOption.Create(500, Types.General, "Play On A Random Map", false, null, false);
             dynamicMapEnableSkeld = CustomOption.Create(501, Types.General, "Enable Skeld Rotation", true, dynamicMap, false);
             dynamicMapEnableMira = CustomOption.Create(502, Types.General, "Enable Mira Rotation", true, dynamicMap, false);

--- a/TheOtherRoles/Patches/GameStartManagerPatch.cs
+++ b/TheOtherRoles/Patches/GameStartManagerPatch.cs
@@ -159,6 +159,18 @@ namespace TheOtherRoles.Patches {
                         }
                     }
 
+                    if (CustomOptionHolder.dynamicImpostor.getBool()) {
+                        var playerCount = GameData.Instance.PlayerCount;
+                        
+                        if (playerCount < 8) {
+                            PlayerControl.GameOptions.NumImpostors = 1;
+                        } else if(playerCount < 13) {
+                            PlayerControl.GameOptions.NumImpostors = 2;
+                        } else {
+                            PlayerControl.GameOptions.NumImpostors = 3;
+                        }
+                    }
+
                     if (CustomOptionHolder.dynamicMap.getBool() && continueStart) {
                         // 0 = Skeld
                         // 1 = Mira HQ

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -123,6 +123,7 @@ namespace TheOtherRoles
         LawyerSetTarget,
         LawyerPromotesToPursuer,
         SetBlanked,
+        dynamicImpostors,
         Bloody,
         SetFirstKill,
         Invert,
@@ -378,6 +379,11 @@ namespace TheOtherRoles
 
         public static void dynamicMapOption(byte mapId) {
             PlayerControl.GameOptions.MapId = mapId;
+        }
+
+        public static void dynamicImpostors(byte impostorCount)
+        {
+            PlayerControl.GameOptions.NumImpostors = impostorCount;
         }
 
         // Role functionality
@@ -970,7 +976,10 @@ namespace TheOtherRoles
                     byte mapId = reader.ReadByte();
                     RPCProcedure.dynamicMapOption(mapId);
                     break;
-
+                case (byte)CustomRPC.dynamicImpostors:
+                    byte impostorCount = reader.ReadByte();
+                    RPCProcedure.dynamicImpostors(impostorCount);
+                    break;
                 // Role functionality
 
                 case (byte)CustomRPC.EngineerFixLights:

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -1274,7 +1274,9 @@ namespace TheOtherRoles
 
         public static void clearAndReload() {
             vulture = null;
-            vultureNumberToWin = Mathf.RoundToInt(CustomOptionHolder.vultureNumberToWin.getFloat());
+            int playerCount = PlayerControl.AllPlayerControls.ToArray().ToList().Count;
+            vultureNumberToWin = (int)Mathf.Floor((float)playerCount / (float)3.0);
+            // vultureNumberToWin = Mathf.RoundToInt(CustomOptionHolder.vultureNumberToWin.getFloat());
             eatenBodies = 0;
             cooldown = CustomOptionHolder.vultureCooldown.getFloat();
             triggerVultureWin = false;


### PR DESCRIPTION
With people joining and leaving regularly having dynamically assigned Impostor and VultureBodies based on the number of players removes the need to constantly monitor the number of players between rounds.


### Dynamic Impostor Count
Creates a toggle in General Options for Dynamic Impostors.

This overrides the initial selection when creating a lobby.  It will set the number of Impostors to:
 1 at < 8 players
 2 at < 12 players
3 at >= 12 players

### Dynamic Vultures to Win

Instead of setting a fixed number of bodies to win its now floor(playerCount / 3.0).
